### PR TITLE
Return IDs that are unmatched. Preserve distinct ID columns

### DIFF
--- a/R/double_entry_check.R
+++ b/R/double_entry_check.R
@@ -24,33 +24,87 @@
 #' errors <- double_entry_check(repository_A, repository_B, id = c("subject", "visit", "case"))
 #' @export
 #' @import dplyr tidyr
-double_entry_check <- function(x, y, id) {
-  
-  if(sum(!(names(x) %in% names(y))) > 0 | sum(!(names(y) %in% names(x))) > 0){
-    stop("column names aren't identical")
-  }
-  
-  if(length(id) > 1){
-    id_x <- do.call(paste, c(x[id], sep="-"))
-    x <- select(x, one_of(names(x)[!(names(x) %in% id)]))
-    x$id <- id_x
-    id_y <- do.call(paste, c(y[id], sep="-"))
-    y <- select(y, one_of(names(y)[!(names(y) %in% id)]))
-    y$id <- id_y
-    id <- "id"
-  } else {
-    names(x)[names(x) == id] <- "id"
-    names(y)[names(y) == id] <- "id"
-  }
-  if(sum(!(x$id %in% y$id)) > 0 | sum(!(y$id %in% x$id)) > 0){
-    warning("Some ids don't match")
-  }
-  
-  x <- gather_(x, "field", "x", names(x)[names(x) != "id"])
-  y <- gather_(y, "field", "y", names(y)[names(y) != "id"])
-  
-  error_table <- inner_join(x, y, c("id", "field")) %>%
-    filter(x != y | is.na(x) & !is.na(y) | !is.na(x) & is.na(y))
-  
-  error_table
+double_entry_check <- function(x, y, id_arg) {
+
+
+if (sum(!(names(x) %in% names(y))) > 0 | sum(!(names(y) %in%
+                                                   names(x))) > 0) {
+        stop("column names aren't identical")
+    }
+    # For multiple id columns
+    if (length(id_arg) > 1) {
+        id_x <- do.call(paste, c(x[id_arg], sep = "-"))
+        x_id$id <- id_x
+        id_y <- do.call(paste, c(y[id_arg], sep = "-"))
+        y_id$id <- id_y
+        id <- "id"
+    }
+    # For single id columns
+    else {
+        x_id <- x %>% mutate(id = !!sym(id_arg))
+        y_id <- y %>% mutate(id = !!sym(id_arg))
+    }
+
+    # Get a tibble of all distinct IDs with the ID columns-values
+    all_id <-
+            bind_rows(
+                x_id
+                , y_id
+            ) %>%
+            select(id, matches(id_arg)) %>%
+            distinct()
+
+    # Check the id column matches between the dataframes
+    if (sum(!(x_id$id %in% y_id$id)) > 0 | sum(!(y_id$id %in% x_id$id)) >
+        0) {
+        warning("Some ids don't match")
+
+
+        # Get ids in x that are not in y
+        in_x_not_y <- anti_join(x_id, y_id, by = "id") %>%
+        select(-starts_with(id_arg)) %>%
+        pivot_longer(
+           , cols = -"id"
+           , names_to = "field",
+           , values_to = "x"
+           , values_transform = list(x = as.character))
+
+        # get ids in y that are not in x
+        in_y_not_x <-
+            anti_join(y_id, x_id, by = "id") %>%
+            select(-starts_with(id_arg)) %>%
+            pivot_longer(
+           # , data = x
+           , cols = -"id"
+           , names_to = "field",
+           , values_to = "y"
+           , values_transform = list(y = as.character))
+    }
+
+    # Pivot data for matching values
+    x_long <- pivot_longer(
+        , data = x_id
+        , cols = -"id"
+        , names_to = "field",
+        , values_to = "x"
+        , values_transform = list(x = as.character))
+    y_long <- pivot_longer(
+        , data = y_id
+        , cols = -"id"
+        , names_to = "field",
+        , values_to = "y"
+        , values_transform = list(y = as.character))
+
+    # Keep records where there are matching record ID and keep if values not matching
+    error_on_match <- inner_join(x_long, y_long, by = c("id", "field")) %>% filter(x !=
+                                                                     y | is.na(x) & !is.na(y) | !is.na(x) & is.na(y))
+
+    # Combine mismatched values from matched ids with unmatched ids-values
+    error_table <- bind_rows(error_on_match, in_y_not_x, in_x_not_y) %>%
+        # Add the columns for the id columns back to the dataframe and remove concatenated version
+        left_join(all_id, by = "id") %>%
+        select(-id) %>%
+        relocate(matches(id_arg))
+
+    return(error_table)
 }


### PR DESCRIPTION
Nice work on this package. I've made some tweaks to the `double_entry_check()` function that I found helpful for my use case.
1. The error table returns rows for IDs that are in one data set but not the other (with `NA` in the x or y column) - potentially helpful when then using the function output to identify all rows that need to be checked
2. The return from the function preserves the ID columns as separate columns rather than a single id column that concatenates the values of the ID columns - probably a marginal gain at best but there might be cases where maintaining the columns to match the original data could be handy

Perhaps they could be added to the package as a new function if not wanting to change `double_entry_check()`